### PR TITLE
Add simple vote mode

### DIFF
--- a/lib/audio_addict/commands/channels.rb
+++ b/lib/audio_addict/commands/channels.rb
@@ -8,7 +8,7 @@ module AudioAddict
       usage "radio channels [SEARCH]"
       usage "radio channels --help"
 
-      param "SEARCH", "Channel name or a partial name to search for."
+      param "SEARCH", "Channel name or a partial name to search for"
 
       example "radio channels"
       example "radio channels metal"

--- a/lib/audio_addict/commands/config.rb
+++ b/lib/audio_addict/commands/config.rb
@@ -17,12 +17,12 @@ module AudioAddict
       option "-s --show", "Show the contents of the config file"
       option "-e --edit", "Open the config file for editing"
 
-      command "get", "Show the value of this config key."
-      command "set", "Set the value of this config key."
-      command "del", "Delete the value of this config key."
-      command "show", "Show the entire config file contents."
-      command "edit", "Open the config file for editing."
-      command "guide", "Show a list of supported config keys and their purpose."
+      command "get", "Show the value of this config key"
+      command "set", "Set the value of this config key"
+      command "del", "Delete the value of this config key"
+      command "show", "Show the entire config file contents"
+      command "edit", "Open the config file for editing"
+      command "guide", "Show a list of supported config keys and their purpose"
 
       example "radio config edit"
       example "radio config set like_log ~/like.log"

--- a/lib/audio_addict/commands/vote.rb
+++ b/lib/audio_addict/commands/vote.rb
@@ -5,15 +5,19 @@ module AudioAddict
 
       help "Start an interactive voting prompt for the currently playing track."
 
-      usage "radio vote"
+      usage "radio vote [--all]"
       usage "radio vote --help"
+
+      option "-a --all", "Show all voting options"
 
       def run(args)
         needs :network, :channel, :session_key
 
+        prompt_style = args['--all'] ? :menu : :simple
+
         NowCmd.new.run args
         puts ""
-        answer = get_user_vote
+        answer = get_user_vote style: prompt_style
         unless answer == :cancel
           say "Voting... "
           current_channel.vote answer
@@ -23,10 +27,23 @@ module AudioAddict
 
     private
 
-      def get_user_vote
+      def get_user_vote(style: :menu)
+        if style == :menu
+          menu_prompt
+        else
+          simple_prompt
+        end
+      end
+
+      def menu_prompt
         options = { "Like" => :up, "Dislike" => :down, 
           "Unvote" => :delete, "Cancel" => :cancel }
         prompt.select "Your Vote :", options, marker: '>'
+      end
+
+      def simple_prompt
+        like = prompt.yes? "Like?"
+        like ? :up : :cancel
       end
 
     end

--- a/spec/audio_addict/commands/commands.yml
+++ b/spec/audio_addict/commands/commands.yml
@@ -42,7 +42,9 @@
 - :cmd: "vote --help"
 - :cmd: "vote"
   :kbd: ['%{enter}']
-- :cmd: "vote"
+- :cmd: "vote --all"
+  :kbd: ['%{enter}']
+- :cmd: "vote --all"
   :kbd: ['%{down}%{down}'] # unvote
 
 # playlist

--- a/spec/fixtures/commands/channels --help
+++ b/spec/fixtures/commands/channels --help
@@ -12,7 +12,7 @@ Options:
 
 Parameters:
   SEARCH
-    Channel name or a partial name to search for.
+    Channel name or a partial name to search for
 
 Examples:
   radio channels

--- a/spec/fixtures/commands/config --help
+++ b/spec/fixtures/commands/config --help
@@ -11,22 +11,22 @@ Usage:
 
 Commands:
   get
-    Show the value of this config key.
+    Show the value of this config key
 
   set
-    Set the value of this config key.
+    Set the value of this config key
 
   del
-    Delete the value of this config key.
+    Delete the value of this config key
 
   show
-    Show the entire config file contents.
+    Show the entire config file contents
 
   edit
-    Open the config file for editing.
+    Open the config file for editing
 
   guide
-    Show a list of supported config keys and their purpose.
+    Show a list of supported config keys and their purpose
 
 Options:
   -s --show

--- a/spec/fixtures/commands/vote --all ({down}{down})
+++ b/spec/fixtures/commands/vote --all ({down}{down})
@@ -1,0 +1,20 @@
+[0;34m  Network [0m: [0;32mDigitally Imported[0m # di
+[0;34m  Channel [0m: [0;32mTrance[0m # trance
+[0;34m    Track [0m: ... [2K[0;34m    Track [0m: [0;32mWanting (feat Molly Bancroft)
+[0m[0;34m       By [0m: [0;32mDennis Sheperd
+[0m
+[?25lYour Vote : [90m(Use arrow keys, press Enter to select)[0m
+[32m> Like[0m
+  Dislike
+  Unvote
+  Cancel[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1GYour Vote : 
+  Like
+[32m> Dislike[0m
+  Unvote
+  Cancel[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1GYour Vote : 
+  Like
+  Dislike
+[32m> Unvote[0m
+  Cancel[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1GYour Vote : [32mUnvote[0m
+[?25hVoting... [2K[0;32mVoted
+[0m

--- a/spec/fixtures/commands/vote --all ({enter})
+++ b/spec/fixtures/commands/vote --all ({enter})
@@ -3,7 +3,10 @@
 [0;34m    Track [0m: ... [2K[0;34m    Track [0m: [0;32mWanting (feat Molly Bancroft)
 [0m[0;34m       By [0m: [0;32mDennis Sheperd
 [0m
-Like? [90m(Y/n)[0m [2K[1GLike? [90m(Y/n)[0m 
-[1A[2K[1GLike? [32mYes[0m
-Voting... [2K[0;32mVoted
+[?25lYour Vote : [90m(Use arrow keys, press Enter to select)[0m
+[32m> Like[0m
+  Dislike
+  Unvote
+  Cancel[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1GYour Vote : [32mLike[0m
+[?25hVoting... [2K[0;32mVoted
 [0m

--- a/spec/fixtures/commands/vote --help
+++ b/spec/fixtures/commands/vote --help
@@ -3,9 +3,12 @@ Vote on the currently playing track
 Start an interactive voting prompt for the currently playing track.
 
 Usage:
-  radio vote
+  radio vote [--all]
   radio vote --help
 
 Options:
+  -a --all
+    Show all voting options
+
   -h --help
     Show this help


### PR DESCRIPTION
Change the vote command to show a simple `Like? (Y/n)` prompt instead of the full 4-option menu.
The menu can still be accessed with `radio vote --all`.
