### PR TITLE
Add channel info command

### DIFF
--- a/bin/radio
+++ b/bin/radio
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 require 'audio_addict'
+include Colsole
 
 router = AudioAddict::CLI.router
 

--- a/lib/audio_addict/channel.rb
+++ b/lib/audio_addict/channel.rb
@@ -35,6 +35,13 @@ module AudioAddict
       track_history.first
     end
 
+    def similar_channels
+      similar = properties['similar_channels']
+      return [] unless similar
+      ids = similar.map { |s| s['similar_channel_id'] }
+      radio.search_by_id ids
+    end
+
     def vote(direction = :up, track: nil)
       track ||= current_track.id
       endpoint = "tracks/#{track}/vote/#{id}"

--- a/lib/audio_addict/commands/channels.rb
+++ b/lib/audio_addict/commands/channels.rb
@@ -5,13 +5,17 @@ module AudioAddict
 
       help "List and search channels in the currently set radio network"
 
-      usage "radio channels [SEARCH]"
+      usage "radio channels [SEARCH --info]"
       usage "radio channels --help"
+
+      option "-i --info", "Show results with additional info, such as channel description and related channels"
 
       param "SEARCH", "Channel name or a partial name to search for"
 
       example "radio channels"
+      example "radio channels --info"
       example "radio channels metal"
+      example "radio channels metal -i"
 
       def run(args)
         needs :network
@@ -23,8 +27,38 @@ module AudioAddict
         channels = search ? radio.search(search) : radio.channels
         
         channels = channels.values
+        if args['--info']
+          show_verbose channels
+        else
+          show_compact channels
+        end
+      end
+
+    private
+
+      def show_verbose(channels)
         channels.each do |channel|
-          say "!txtgrn!#{channel.key.rjust 25} !txtblu!#{channel.name.strip}"
+          say ""
+          say "!txtgrn!#{channel.name.ljust 22} !txtrst!# #{channel.key}"
+          say ""
+          say word_wrap "#{channel.description}"
+          say ""
+
+          similar = channel.similar_channels
+
+          if similar.any?
+            say "Similar Channels:"
+            similar.each do |key, similar|
+              say "- !txtblu!#{similar.name.ljust 20}!txtrst! # #{key}"
+            end
+            say ""
+          end
+        end
+      end
+
+      def show_compact(channels)
+        channels.each do |channel|
+          say "!txtblu!#{channel.key.rjust 25} !txtgrn!#{channel.name.strip}"
         end
       end
       

--- a/lib/audio_addict/radio.rb
+++ b/lib/audio_addict/radio.rb
@@ -60,6 +60,11 @@ module AudioAddict
       end 
     end
 
+    def search_by_id(ids)
+      ids = [ids] unless ids.is_a? Array
+      channels.select { |_key, channel| ids.include? channel.id }
+    end
+
     def [](channel_key)
       channels[channel_key]
     end

--- a/spec/audio_addict/commands/commands.yml
+++ b/spec/audio_addict/commands/commands.yml
@@ -33,6 +33,8 @@
 - :cmd: "channels"
 - :cmd: "channels tran"
 - :cmd: "channels --help"
+- :cmd: "channels --info"
+- :cmd: "channels tran --info"
 
 # now
 - :cmd: "now"

--- a/spec/fixtures/commands/channels
+++ b/spec/fixtures/commands/channels
@@ -1,7 +1,7 @@
 [4;32mDigitally Imported
 
-[0m[0;32m            classictrance [0;34mClassic Trance
-[0m[0;32m                    dance [0;34mDance
-[0m[0;32m                      ebm [0;34mEBM
-[0m[0;32m                   trance [0;34mTrance
+[0m[0;34m            classictrance [0;32mClassic Trance
+[0m[0;34m                    dance [0;32mDance
+[0m[0;34m                      ebm [0;32mEBM
+[0m[0;34m                   trance [0;32mTrance
 [0m

--- a/spec/fixtures/commands/channels --help
+++ b/spec/fixtures/commands/channels --help
@@ -3,10 +3,14 @@ Show list of channels
 List and search channels in the currently set radio network
 
 Usage:
-  radio channels [SEARCH]
+  radio channels [SEARCH --info]
   radio channels --help
 
 Options:
+  -i --info
+    Show results with additional info, such as channel description and related
+    channels
+
   -h --help
     Show this help
 
@@ -16,4 +20,6 @@ Parameters:
 
 Examples:
   radio channels
+  radio channels --info
   radio channels metal
+  radio channels metal -i

--- a/spec/fixtures/commands/channels --info
+++ b/spec/fixtures/commands/channels --info
@@ -1,0 +1,34 @@
+[4;32mDigitally Imported
+
+[0m
+[0;32mClassic Trance         [0m# classictrance
+
+classictrance description
+
+Similar Channels:
+- [0;34mDance               [0m # dance
+- [0;34mTrance              [0m # trance
+
+
+[0;32mDance                  [0m# dance
+
+dance description
+
+Similar Channels:
+- [0;34mClassic Trance      [0m # classictrance
+- [0;34mTrance              [0m # trance
+
+
+[0;32mEBM                    [0m# ebm
+
+ebm description
+
+
+[0;32mTrance                 [0m# trance
+
+trance description
+
+Similar Channels:
+- [0;34mClassic Trance      [0m # classictrance
+- [0;34mDance               [0m # dance
+

--- a/spec/fixtures/commands/channels tran
+++ b/spec/fixtures/commands/channels tran
@@ -1,5 +1,5 @@
 [4;32mDigitally Imported
 
-[0m[0;32m            classictrance [0;34mClassic Trance
-[0m[0;32m                   trance [0;34mTrance
+[0m[0;34m            classictrance [0;32mClassic Trance
+[0m[0;34m                   trance [0;32mTrance
 [0m

--- a/spec/fixtures/commands/channels tran --info
+++ b/spec/fixtures/commands/channels tran --info
@@ -1,0 +1,20 @@
+[4;32mDigitally Imported
+
+[0m
+[0;32mClassic Trance         [0m# classictrance
+
+classictrance description
+
+Similar Channels:
+- [0;34mDance               [0m # dance
+- [0;34mTrance              [0m # trance
+
+
+[0;32mTrance                 [0m# trance
+
+trance description
+
+Similar Channels:
+- [0;34mClassic Trance      [0m # classictrance
+- [0;34mDance               [0m # dance
+

--- a/spec/mock_api/config.yml
+++ b/spec/mock_api/config.yml
@@ -1,0 +1,58 @@
+:channels:
+- :id: 1
+  :key: "trance"
+  :description: "trance description"
+  :name: "Trance"
+  :asset_id: 1
+  :similar_channels:
+  - :similar_channel_id: 2
+  - :similar_channel_id: 4
+- :id: 2
+  :key: "dance"
+  :description: "dance description"
+  :name: "Dance"
+  :asset_id: 2
+  :similar_channels:
+  - :similar_channel_id: 1
+  - :similar_channel_id: 4
+- :id: 3
+  :key: "ebm"
+  :description: "ebm description"
+  :name: "EBM"
+  :asset_id: 3
+- :id: 4
+  :key: "classictrance"
+  :description: "classictrance description"
+  :name: "Classic Trance"
+  :asset_id: 4
+  :similar_channels:
+  - :similar_channel_id: 1
+  - :similar_channel_id: 2
+- :id: 5
+  :key: "hiddenchannel"
+  :description: "hiddenchannel description"
+  :name: "Hidden Dance"
+- :id: 6
+  :key: "anotherhidden"
+  :description: "anotherhidden description"
+  :name: "XHidden Dance"
+  :asset_id: 6
+
+:track_history:
+- :track_id: 1
+  :artist: "Dennis Sheperd"
+  :title: "Wanting (feat Molly Bancroft)"
+- :track_id: 2
+  :artist: "D.Wingel"
+  :title: "Alone in the Space"
+- :track_id: 3
+  :artist: "Lulu Rouge"
+  :title: "Sign Me Out"
+
+:login:
+  :key: 'session-key-new'
+  :member:
+    :listen_key: "listen-key-new"
+    :user_type: 'premium'
+    :email:  'eli@marko.com'
+

--- a/spec/mock_api/server.rb
+++ b/spec/mock_api/server.rb
@@ -1,11 +1,20 @@
 require 'sinatra'
 require 'byebug'
+require 'yaml'
 
 set :port, 3000
 set :bind, '0.0.0.0'
 
 def json(hash)
   JSON.pretty_generate hash
+end
+
+def config
+  @config ||= YAML.load_file(config_file)
+end
+
+def config_file
+  File.expand_path 'config.yml', __dir__
 end
 
 # Handshake
@@ -15,38 +24,17 @@ end
 
 # Channels
 get '/:network/channels' do
-  response = [
-    { id: 1, key: "trance",         name: "Trance",          asset_id: 1 },
-    { id: 2, key: "dance",          name: "Dance",           asset_id: 2 },
-    { id: 3, key: "ebm",            name: "EBM",             asset_id: 3 },
-    { id: 4, key: "classictrance",  name: "Classic Trance",  asset_id: 4 },
-    { id: 5, key: "hiddenchannel",  name: "Hidden Dance"                 },
-    { id: 6, key: "anotherhidden",  name: "XHidden Dance",   asset_id: 6 },
-  ]
-  json response
+  json config[:channels]
 end
 
 # Tracks
 get '/:network/track_history/channel/*' do
-  response = [
-    { track_id: 1, artist: "Dennis Sheperd", title: "Wanting (feat Molly Bancroft)" },
-    { track_id: 2, artist: "D.Wingel",       title: "Alone in the Space" },
-    { track_id: 3, artist: "Lulu Rouge",     title: "Sign Me Out" },
-  ]
-  json response
+  json config[:track_history]
 end
 
 # Login
 post '/:network/member_sessions' do
-  response = {
-    key: 'session-key-new',
-    member: {
-      listen_key: "listen-key-new",
-      user_type: 'premium',
-      email:  'eli@marko.com',
-    }
-  }
-  json response
+  json config[:login]
 end
 
 # Vote


### PR DESCRIPTION
Add `radio channels --info` flag, to show additional info for each channel, such as description and similar channels.

In addition, some improvements were made to the mock server endpoint configuration.