### PR TITLE
Fix chicken and egg situation with login and network

### DIFF
--- a/lib/audio_addict/api.rb
+++ b/lib/audio_addict/api.rb
@@ -45,7 +45,7 @@ module AudioAddict
     def session(username, password)
       params = { member_session: { username: username, password: password } }
       basic_auth
-      response http.post "/#{network}/member_sessions", body: params
+      response http.post "/#{network || 'di'}/member_sessions", body: params
     end
 
     def session_key

--- a/lib/audio_addict/commands/base.rb
+++ b/lib/audio_addict/commands/base.rb
@@ -24,7 +24,7 @@ module AudioAddict
       end
 
       def current_network
-        Config.network
+        Config.network || 'di'
       end
 
       def current_channel

--- a/lib/audio_addict/commands/base.rb
+++ b/lib/audio_addict/commands/base.rb
@@ -24,7 +24,7 @@ module AudioAddict
       end
 
       def current_network
-        Config.network || 'di'
+        Config.network
       end
 
       def current_channel

--- a/lib/audio_addict/commands/config.rb
+++ b/lib/audio_addict/commands/config.rb
@@ -125,7 +125,7 @@ module AudioAddict
 
       def optional_keys
         {
-          like_log: 'config like_log PATH',
+          like_log: 'config set like_log PATH',
         }
       end
 

--- a/spec/fixtures/commands/config check #missing_config
+++ b/spec/fixtures/commands/config check #missing_config
@@ -2,5 +2,5 @@
 [0;31mError  [0m : Key [0;32mlisten_key[0m is not set. Fix with [0;35mradio login[0m.
 [0;31mError  [0m : Key [0;32mnetwork[0m is not set. Fix with [0;35mradio set[0m.
 [0;31mError  [0m : Key [0;32mchannel[0m is not set. Fix with [0;35mradio set[0m.
-[0;33mWarning[0m : Key [0;32mlike_log[0m is not set. Fix with [0;35mradio config like_log PATH[0m.
+[0;33mWarning[0m : Key [0;32mlike_log[0m is not set. Fix with [0;35mradio config set like_log PATH[0m.
 Done. 4 errors, 1 warnings.


### PR DESCRIPTION
Chicken or egg?

- In order to login, you needed to set a network first (due to the API endpoint).
- In order to set the network with `radio set`, you needed to login first

Fixed by providing a fallback network to the login (session) endpoint.

In addition, fixed incorrect instructions in `radio config check`.