### PR TITLE
Add ZenRadio network

### DIFF
--- a/.changelog.old.md
+++ b/.changelog.old.md
@@ -1,12 +1,3 @@
-Change Log
-========================================
-
-Untagged - Latest
-----------------------------------------
-
-- Add ZenRadio network
-
-
 ## [v0.1.9](https://github.com/DannyBen/audio_addict/tree/v0.1.9) (2018-12-14)
 [Full Changelog](https://github.com/DannyBen/audio_addict/compare/v0.1.8...v0.1.9)
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source "https://rubygems.org"
 
 gem 'byebug'
-# gem 'github_changelog_generator'
 gem 'lp'
 gem 'pretty_trace'
 gem 'rspec'

--- a/Runfile
+++ b/Runfile
@@ -19,10 +19,11 @@ action :console, :c do
   run "bundle exec bin/console"
 end
 
-help   "Generate changelog"
+help   "Generate changelog and append old changelog"
 action :changelog do
-  run 'github_changelog_generator --cache-file tmp/changlog-cache'  
-  run "git commit -am 'update changelog' && git push"
+  run "git changelog --save"
+  # append older changelog (prior to switching to git-changelog)
+  run "cat .changelog.old.md >> CHANGELOG.md"
 end
 
 help   "Run test mock server"

--- a/devnotes.md
+++ b/devnotes.md
@@ -20,14 +20,3 @@ to STDERR. You can use shell redirection to save it to a file. For example:
 ```shell
 $ radio history 2> debug.log
 ```
-
-
-Zen Radio issues
---------------------------------------------------
-
-The newly added ZenRadio does not provide track history at the moment.
-
-- Works: https://api.audioaddict.com/v1/di/track_history/channel/324
-- Doesn't work: https://api.audioaddict.com/v1/zenradio/track_history/channel/457
-
-You can simply open these in a browser.

--- a/devnotes.md
+++ b/devnotes.md
@@ -20,3 +20,14 @@ to STDERR. You can use shell redirection to save it to a file. For example:
 ```shell
 $ radio history 2> debug.log
 ```
+
+
+Zen Radio issues
+--------------------------------------------------
+
+The newly added ZenRadio does not provide track history at the moment.
+
+- Works: https://api.audioaddict.com/v1/di/track_history/channel/324
+- Doesn't work: https://api.audioaddict.com/v1/zenradio/track_history/channel/457
+
+You can simply open these in a browser.

--- a/lib/audio_addict/commands/api.rb
+++ b/lib/audio_addict/commands/api.rb
@@ -10,9 +10,9 @@ module AudioAddict
 
       param "ENDPOINT", "API endpoint path"
 
-      example "radio channels"
-      example "radio get track_history/channel/1"
-      example "radio post tracks/1/vote/2/up"
+      example "radio api channels"
+      example "radio api get track_history/channel/1"
+      example "radio api post tracks/1/vote/2/up"
 
       def run
         needs :network

--- a/lib/audio_addict/commands/log.rb
+++ b/lib/audio_addict/commands/log.rb
@@ -52,7 +52,7 @@ module AudioAddict
         tree = log.tree
 
         say ""
-        network = prompt.select "Network:", tree.keys, symbols: { marker: ">" }, filter: true
+        network = prompt.select "Network:", tree.keys, symbols: { marker: ">" }, filter: true, per_page: 10
         channel = prompt.select "Channel:", tree[network].keys, symbols: { marker: ">" }, filter: true, per_page: page_size
         artist = prompt.select "Artist:", tree[network][channel].keys, symbols: { marker: ">" }, filter: true, per_page: page_size
 

--- a/lib/audio_addict/commands/playlist.rb
+++ b/lib/audio_addict/commands/playlist.rb
@@ -56,10 +56,7 @@ module AudioAddict
       private
 
       def generate_config(outfile)
-        data = {
-          template: "http://prem2.#{radio.domain}:80/%{channel_key}?%{listen_key}",
-        }
-
+        data = { template: radio.url_template }
         channels = {}
 
         radio.channels.each do |key, channel|

--- a/lib/audio_addict/commands/set.rb
+++ b/lib/audio_addict/commands/set.rb
@@ -92,7 +92,7 @@ module AudioAddict
       def network_prompt(networks)
         options = networks.invert
         options["Skip"] = :cancel
-        prompt.select "Network :", options, symbols: { marker: ">" }, filter: true
+        prompt.select "Network :", options, symbols: { marker: ">" }, filter: true, per_page: 10
       end
 
       def save_channel(channel, echo: true)

--- a/lib/audio_addict/radio.rb
+++ b/lib/audio_addict/radio.rb
@@ -52,6 +52,11 @@ module AudioAddict
       DOMAINS[network.to_sym]
     end
 
+    def url_template
+      channel_path = network == "zenradio" ? "zr%{channel_key}_aac" : "%{channel_key}"
+      "http://prem2.#{domain}:80/#{channel_path}?%{listen_key}"
+    end
+
     def channels
       @channels ||= channels!
     end

--- a/lib/audio_addict/radio.rb
+++ b/lib/audio_addict/radio.rb
@@ -11,6 +11,7 @@ module AudioAddict
       radiotunes: "Radio Tunes",
       jazzradio: "Jazz Radio",
       classicalradio: "Classical Radio",
+      zenradio: "Zen Radio",
     }
 
     DOMAINS = {
@@ -19,6 +20,7 @@ module AudioAddict
       radiotunes: "radiotunes.com",
       jazzradio: "jazzradio.com",
       classicalradio: "classicalradio.com",
+      zenradio: "zenradio.com",
     }
 
     def self.networks(search = nil)

--- a/spec/approvals/commands/api --help
+++ b/spec/approvals/commands/api --help
@@ -17,6 +17,6 @@ Parameters:
     API endpoint path
 
 Examples:
-  radio channels
-  radio get track_history/channel/1
-  radio post tracks/1/vote/2/up
+  radio api channels
+  radio api get track_history/channel/1
+  radio api post tracks/1/vote/2/up

--- a/spec/approvals/commands/set ({down} {down})
+++ b/spec/approvals/commands/set ({down} {down})
@@ -1,16 +1,18 @@
-Network : (Press ↑/↓/←/→ arrow to move, Enter to select and letters to filter)
+Network : (Press ↑/↓ arrow to move, Enter to select and letters to filter)
 > Digitally Imported
   Rock Radio
   Radio Tunes
   Jazz Radio
   Classical Radio
-  Zen RadioNetwork : 
+  Zen Radio
+  SkipNetwork : 
   Digitally Imported
 > Rock Radio
   Radio Tunes
   Jazz Radio
   Classical Radio
-  Zen RadioNetwork : Rock Radio
+  Zen Radio
+  SkipNetwork : Rock Radio
 Channel : (Press ↑/↓ arrow to move, Enter to select and letters to filter)
 > Cancel
   Classic Trance       # classictrance

--- a/spec/approvals/commands/set ({down} {down})
+++ b/spec/approvals/commands/set ({down} {down})
@@ -1,16 +1,16 @@
-Network : (Press ↑/↓ arrow to move, Enter to select and letters to filter)
+Network : (Press ↑/↓/←/→ arrow to move, Enter to select and letters to filter)
 > Digitally Imported
   Rock Radio
   Radio Tunes
   Jazz Radio
   Classical Radio
-  SkipNetwork : 
+  Zen RadioNetwork : 
   Digitally Imported
 > Rock Radio
   Radio Tunes
   Jazz Radio
   Classical Radio
-  SkipNetwork : Rock Radio
+  Zen RadioNetwork : Rock Radio
 Channel : (Press ↑/↓ arrow to move, Enter to select and letters to filter)
 > Cancel
   Classic Trance       # classictrance


### PR DESCRIPTION
Now that ZenRadio is finally fully available through the API, it can be included.

This network has a slightly different channel URL template, so the responsibility for providing the URL template was moved from the `playlist` command to the `Radio#url_template` method.