### PR TITLE
Allow settings the --count for the download command using an environment variable

### DIFF
--- a/bin/radio
+++ b/bin/radio
@@ -8,7 +8,7 @@ router = AudioAddict::CLI.router
 begin
   exit router.run ARGV
 
-rescue AudioAddict::Interrupt, TTY::Reader::InputInterrupt
+rescue Interrupt, AudioAddict::Interrupt, TTY::Reader::InputInterrupt
   say "\nGoodbye"
   exit 1  
 
@@ -30,4 +30,5 @@ rescue => e
   say "!undred!ERROR: #{e.class}"
   say e.message
   exit 1
+
 end

--- a/lib/audio_addict/commands/download.rb
+++ b/lib/audio_addict/commands/download.rb
@@ -11,13 +11,15 @@ module AudioAddict
       usage "radio download --help"
 
       option "-l --lines N", "Number of log lines to download [default: 1]"
-      option "-c --count N", "Number of YouTube search results to download [default: 1]"
+      option "-c --count N", "Number of YouTube search results to download\nDefaults to the value of the AUDIO_ADDICT_DOWNLOAD_COUNT environment variable, or 1"
 
       param "QUERY", "YouTube search query"
 
       command "current", "Download the currently playing song"
       command "log", "Download the last N songs from the like-log"
       command "search", "Download any song matching the Youtube search query"
+
+      environment "AUDIO_ADDICT_DOWNLOAD_COUNT", "Set the default download count (--count)"
 
       example "radio download current"
       example "radio download current --count 3"
@@ -26,7 +28,6 @@ module AudioAddict
 
       def current_command
         needs :network, :channel
-        count = args['--count']
 
         say "!txtblu!Downloading !txtrst!: ... "
 
@@ -40,7 +41,6 @@ module AudioAddict
 
       def log_command
         needs :like_log
-        count = args['--count']
         lines = args['--lines']&.to_i
 
         data = log.data[-lines..-1]
@@ -54,13 +54,16 @@ module AudioAddict
 
       def search_command
         query = args['QUERY']
-        count = args['--count']
 
         say "\n!txtblu!Downloading !txtgrn!: #{query}"
         Youtube.new(query).get count
       end
 
     private
+
+      def count
+        args['--count']&.to_i || ENV['AUDIO_ADDICT_DOWNLOAD_COUNT']&.to_i || 1
+      end
 
       def log
         @log ||= Log.new

--- a/lib/audio_addict/youtube.rb
+++ b/lib/audio_addict/youtube.rb
@@ -26,7 +26,7 @@ module AudioAddict
   private
 
     def execute(command)
-      if ENV['YOUTUBE_DL_DRY_RUN']
+      if ENV['AUDIO_ADDICT_DOWNLOAD_DRY_RUN']
         puts "DRY RUN: #{command}"
         true
       else

--- a/spec/approvals/commands/download --help
+++ b/spec/approvals/commands/download --help
@@ -24,7 +24,9 @@ Options:
     Number of log lines to download [default: 1]
 
   -c --count N
-    Number of YouTube search results to download [default: 1]
+    Number of YouTube search results to download
+    Defaults to the value of the AUDIO_ADDICT_DOWNLOAD_COUNT environment
+    variable, or 1
 
   -h --help
     Show this help
@@ -32,6 +34,10 @@ Options:
 Parameters:
   QUERY
     YouTube search query
+
+Environment Variables:
+  AUDIO_ADDICT_DOWNLOAD_COUNT
+    Set the default download count (--count)
 
 Examples:
   radio download current

--- a/spec/approvals/commands/download current env (system call)
+++ b/spec/approvals/commands/download current env (system call)
@@ -1,0 +1,3 @@
+Downloading : ... 
+Downloading : Dennis Sheperd, Wanting (feat Molly Bancroft)
+DRY RUN: youtube-dl --extract-audio --audio-format mp3 ytsearch2:"Dennis Sheperd, Wanting (feat Molly Bancroft)"

--- a/spec/audio_addict/commands/download_spec.rb
+++ b/spec/audio_addict/commands/download_spec.rb
@@ -5,17 +5,31 @@ describe Commands::DownloadCmd do
 
   describe "get" do
     before do
-      ENV['YOUTUBE_DL_DRY_RUN'] = nil
       expect_any_instance_of(Youtube).to receive(:command_exist?).with('youtube-dl').and_return true
     end
 
-    after do
-      ENV['YOUTUBE_DL_DRY_RUN'] = '1'
+    context "when AUDIO_ADDICT_DOWNLOAD_DRY_RUN is unset" do
+      before do
+        ENV['AUDIO_ADDICT_DOWNLOAD_DRY_RUN'] = nil
+      end
+
+      after do
+        ENV['AUDIO_ADDICT_DOWNLOAD_DRY_RUN'] = '1'
+      end
+
+      it "runs the system command" do
+        expect_any_instance_of(Youtube).to receive(:system).and_return(true)
+        expect { subject.run %w[download current] }.to output_approval('commands/download current (system call)')
+      end
     end
 
-    it "runs the system command" do
-      expect_any_instance_of(Youtube).to receive(:system).and_return(true)
-      expect { subject.run %w[download current] }.to output_approval('commands/download current (system call)')
+    context "with AUDIO_ADDICT_DOWNLOAD_COUNT" do
+      before { ENV['AUDIO_ADDICT_DOWNLOAD_COUNT'] = "2" }
+      after { ENV['AUDIO_ADDICT_DOWNLOAD_COUNT'] = nil }
+
+      it "uses the value for --count" do
+        expect { subject.run %w[download current] }.to output_approval('commands/download current env (system call)')
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,7 +15,7 @@ ENV['COLUMNS'] = '80'
 ENV['LINES'] = '30'
 
 # Do not run youtube-dl, instead show the command
-ENV['YOUTUBE_DL_DRY_RUN'] = '1'
+ENV['AUDIO_ADDICT_DOWNLOAD_DRY_RUN'] = '1'
 
 reset_config
 


### PR DESCRIPTION
- Allow using the `AUDIO_ADDICT_DOWNLOAD_COUNT ` environment variable to set the default value for the `radio download --count N` argument.
- Fix the bin entrypoint to also exit gracefully on standard using iterrupt
- Rename `YOUTUBE_DL_DRY_RUN` to `AUDIO_ADDICT_DOWNLOAD_DRY_RUN` for consistency (this is only used internally or during development).
